### PR TITLE
Remove xyz tiles when raster mbtiles conversion is complete

### DIFF
--- a/gccd_pkg/gccd/generate_tiles.py
+++ b/gccd_pkg/gccd/generate_tiles.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import shutil
 import json
 import requests
 import socket
@@ -116,6 +117,9 @@ def convert_xyz_to_mbtiles(output_directory, output_filename):
         subprocess.call(command, shell=True)
         print()
         print("\033[1m\033[32mRaster MBTiles file generated:\033[0m", f"{raster_mbtiles_output_path}")
+
+        shutil.rmtree(xyz_output_dir)
+        print(f"Deleted XYZ directory: {xyz_output_dir}")
     except subprocess.CalledProcessError:
         raise RuntimeError(f"\033[1m\033[31mFailed to generate MBTiles using command:\033[0m {command}")
     


### PR DESCRIPTION
Resolves https://github.com/ConservationMetrics/guardianconnector-change-detection/issues/6. A quick PR to remove the `xyz/` tiles dir once raster mbtiles conversion is complete (they are not needed as an output at this time and bloat the overall # of files and filesize.)

Can point this to `main` once the stacked `httpservice` branches are merged.