### PR TITLE
Catch more failures

### DIFF
--- a/scripts/generate_tiles.py
+++ b/scripts/generate_tiles.py
@@ -24,8 +24,12 @@ def generate_vector_mbtiles(output_directory, output_filename):
     command = f"tippecanoe -o {vector_mbtiles_output_path} --force {output_directory}/{output_filename}.geojson"
 
     try:
-        os.system(command)
-        print(f"\033[1m\033[32mVector MBTiles file generated:\033[0m {vector_mbtiles_output_path}")
+        ret = os.system(command)
+        if ret == 0:
+            print(f"\033[1m\033[32mVector MBTiles file generated:\033[0m {vector_mbtiles_output_path}")
+        else:
+            print(f"\033[1m\033[31mError generating Vector MBTiles:\033[0m tippecanoe exit code {ret}")
+            sys.exit(1)
     except Exception as e:
         print(f"\033[1m\033[31mError generating Vector MBTiles:\033[0m {e}")
         sys.exit(1)

--- a/scripts/serve_maps.py
+++ b/scripts/serve_maps.py
@@ -101,6 +101,13 @@ def serve_tileserver_gl(output_directory, output_filename, env_port):
         proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
         while True:
+            if proc.poll() is not None:
+                subprocess.run("stty sane", shell=True)
+                print(
+                    "\033[1m\033[31mTileServer-GL process terminated, check docker logs\033[0m"
+                )
+                sys.exit(1)
+
             line = proc.stdout.readline()
             if "Startup complete" in line:
                 subprocess.run('stty sane', shell=True)


### PR DESCRIPTION
# Goal

When our Python flow calls out to external scripts, those scripts might fail. This PR adds detection of those failures, and will fail the Python flow accordingly.

# What I changed

1. check tippecanoe exit code. 0 means success, all others represent something going wrong
2. poll docker process (running tileserver-gl) to make sure it hasn't crashed.