### PR TITLE
Fix docker build: install tippecanoe dependency

### DIFF
--- a/httpservice/Dockerfile
+++ b/httpservice/Dockerfile
@@ -1,7 +1,12 @@
-FROM python:3.11-slim
+FROM python:3.11-slim as tippecanoe-build-image
 
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential libsqlite3-dev zlib1g-dev git
 RUN git clone https://github.com/mapbox/tippecanoe.git && cd tippecanoe && make -j && make install && cd .. && rm -r tippecanoe
+
+
+#-#-#-#-#-#-#
+FROM python:3.11-slim
+COPY --from=tippecanoe-build-image /usr/local/bin/tile-join /usr/local/bin/tippecanoe* /usr/local/bin/
 
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt

--- a/httpservice/Dockerfile
+++ b/httpservice/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential libsqlite3-dev zlib1g-dev git
+RUN git clone https://github.com/mapbox/tippecanoe.git && cd tippecanoe && make -j && make install && cd .. && rm -r tippecanoe
 
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt

--- a/httpservice/README.md
+++ b/httpservice/README.md
@@ -24,7 +24,7 @@ or
     DATE=`date "+%Y%m%d.%H%M%S"`
     GIT_HEAD=$(git rev-parse --short HEAD)
     IMAGE_TAG=$DATE-$GIT_HEAD
-    ./build.sh guardiancr.azurecr.io/gccr:${IMAGE_TAG}
+    ./build.sh guardiancr.azurecr.io/gccd:${IMAGE_TAG}
 
 ## Run HTTP server
 


### PR DESCRIPTION
I forgot to install tippecanoe into the httpserver Docker image.

This builds from source, which is the recommendation for Ubuntu-based OS (our base image is using Debian but I didn't see a better way to install).  I use a multi-stage Docker build so that the build-essentials and git don't end up in the final  image we deploy.