### PR TITLE
Enforce API-key security on /changemaps/ endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# gccd library
 MAPBOX_ACCESS_TOKEN=
 MAPBOX_STYLE=mapbox://styles/mapbox/satellite-streets-v11
 MAPBOX_ZOOM=1
@@ -7,4 +8,9 @@ RASTER_IMAGERY_URL=http://ecn.t3.tiles.virtualearth.net/tiles/a{q}.jpeg?g=1
 RASTER_IMAGERY_ATTRIBUTION=© 2023 Microsoft (Bing Maps)
 RASTER_MBTILES_MAX_ZOOM=15
 RASTER_BUFFER_SIZE=5
+
+# gccd script
 PORT=8080
+
+# httpserver
+ALLOWED_API_KEY=

--- a/httpservice/app/app.py
+++ b/httpservice/app/app.py
@@ -5,8 +5,9 @@ import tempfile
 from typing import Any
 
 import fastapi
-
 import gccd
+
+from .security import check_apikey_header
 
 
 app = fastapi.FastAPI()
@@ -39,7 +40,7 @@ def create_tarfile(directory, tar_filename):
                 tar.add(full_path, arcname=relative_path)
 
 
-@app.post("/changemaps/")
+@app.post("/changemaps/", dependencies=[fastapi.Security(check_apikey_header)])
 async def make_changemaps(
     feacoll: Any = fastapi.Body(), output_tar=fastapi.Depends(sendable_tempfile)
 ):

--- a/httpservice/app/security.py
+++ b/httpservice/app/security.py
@@ -1,0 +1,25 @@
+import os
+
+import fastapi
+import starlette
+from fastapi.security.api_key import APIKeyHeader
+
+
+ALLOWED_API_KEY = os.environ["ALLOWED_API_KEY"]
+API_KEY_NAME = "X-API-KEY"
+api_key_header_auth = APIKeyHeader(name=API_KEY_NAME, auto_error=True)
+
+
+async def check_apikey_header(
+    api_key_header: str = fastapi.Security(api_key_header_auth),
+):
+    """Enforce API-key security
+
+    Assert that the provided X-API-KEY header value matches the ALLOWED_API_KEY
+    read from environment
+    """
+    if api_key_header != ALLOWED_API_KEY:
+        raise fastapi.HTTPException(
+            status_code=starlette.status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API Key",
+        )


### PR DESCRIPTION
To avoid outside actors from hitting the `changemaps` endpoint and wasting resources (crawling bing, using Mapbox requests...) we now require a specific `X-API-KEY` HTTP header on requests to that endpoint.

The allowed value must be set in a new environment variable (which I've already set in our Azure deployment).