### PR TITLE
Small fixes to Python code and READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ The script follows these steps:
 
 For Python, these steps are all contained in the gccd package's `main.py` script. For Docker, we need to split these up due to compose service orchestration; steps 1-9 are handled in  `docker-generate.py`, step 10 is handled by running a `tileserver-gl` service, and step 11 is handled in `docker-tileserver-compile.py`.
 
+## Configure
+
+These are the environmental variables you will need to provide in your hosting environment.
+
+* `MAPBOX_ACCESS_TOKEN` <span style="color:red">(required)</span>: Access token for your Mapbox account, required for your HTML map to work.
+* `MAPBOX_STYLE`: The background style used for your HTML map. Defaults to mapbox://styles/mapbox/satellite-streets-v11 if not provided.
+* `MAPBOX_ZOOM`: Default zoom level for your HTML map. Defaults to 1 if not provided.
+* `MAPBOX_CENTER_LONGITUDE`: Default center longitude for your HTML map. Defaults to 0 if not provided.
+* `MAPBOX_CENTER_LATITUDE`: Default center latitude for your HTML map. Defaults to 0 if not provided.
+* `RASTER_IMAGERY_URL` <span style="color:red">(required)</span>: URL for the source of your satellite imagery tiles that will be downloaded for offline usage. Note that if an API token is required that it must be appended to this URL.
+* `RASTER_IMAGERY_ATTRIBUTION`: Attribution for your satellite imagery source. Currently this is added to the metadata of the raster MBTiles file.
+* `RASTER_MBTILES_MAX_ZOOM`: Maximum zoom level up until which imagery tiles will be downloaded. Defaults to 14 if not provided.
+* `RASTER_BUFFER_SIZE`: A buffer (in kilometers) to expand the imagery download beyond the bounding box of your GeoJSON file. Defaults to 0 if not provided.
+* `PORT` <span style="color:grey">(for GCCD Python script)</span>: If running the Python scripts outside of Docker, you may choose to specify a different port for `tileserver-gl` to run on. Defaults to 8080 if not specified.
+* `ALLOWED_API_KEY`  <span style="color:grey">(for HTTP server)</span>: To authorize HTTP requests to the server endpoints.
+
+For Python or Docker execution, create a `.env` file using the provided example as a template. 
+
 ## Run the script with Docker Compose
 
 Execute the script using the command:
@@ -45,9 +63,10 @@ See [`httpservice/README.md`](httpservice/README.md).
 
 ## Outputs
 
+This script will generate a rasterized MBTiles format for tiles that overlay your input GeoJSON on top of a raster source (typically satellite imagery), as well as an HTML map to preview your input GeoJSON on a Mapbox style (currently `satellite-streets-11`).
+
 The script also generates a `mapbox-map` directory with map resources placed in accordance to the Mapbox style spec:
 
-* **XYZ tiles**:  Satellite imagery tiles that overlap with the input GeoJSON's bounding box. (These are used to generate the Raster MBTiles and could be deleted, but are kept here in case they are useful for a different purpose.)
 * **Vector MBTiles**: MBTiles format of the GeoJSON, intended for map stylesheets in data collection apps.
 * **Raster MBTiles**: MBTiles format of the satellite imagery tiles.
 * **Fonts and sprites**: font and sprite glyph resources required to load a Mapbox map. Only Open Sans Regular is compiled (which is what is used in the style).
@@ -71,9 +90,6 @@ example/
     └── tiles/
         ├── example-raster.mbtiles
         └── example-vector.mbtiles
-        └── xyz/
-            ├── ... metadata.json
-            ├── ... (XYZ tile files)
 ```
 
 ## How to use the outputs

--- a/gccd_pkg/README.md
+++ b/gccd_pkg/README.md
@@ -1,20 +1,5 @@
 # gccd Python library
 
-## Configure
-
-Create a `.env` file using the provided example as a template. The variables represent the following:
-
-* `MAPBOX_ACCESS_TOKEN` <span style="color:red">(required)</span>: Access token for your Mapbox account, required for your HTML map to work.
-* `MAPBOX_STYLE`: The background style used for your HTML map. Defaults to mapbox://styles/mapbox/satellite-streets-v11 if not provided.
-* `MAPBOX_ZOOM`: Default zoom level for your HTML map. Defaults to 1 if not provided.
-* `MAPBOX_CENTER_LONGITUDE`: Default center longitude for your HTML map. Defaults to 0 if not provided.
-* `MAPBOX_CENTER_LATITUDE`: Default center latitude for your HTML map. Defaults to 0 if not provided.
-* `RASTER_IMAGERY_URL` <span style="color:red">(required)</span>: URL for the source of your satellite imagery tiles that will be downloaded for offline usage. Note that if an API token is required that it must be appended to this URL.
-* `RASTER_IMAGERY_ATTRIBUTION`: Attribution for your satellite imagery source. Currently this is added to the metadata of the raster MBTiles file.
-* `RASTER_MBTILES_MAX_ZOOM`: Maximum zoom level up until which imagery tiles will be downloaded. Defaults to 14 if not provided.
-* `RASTER_BUFFER_SIZE`: A buffer (in kilometers) to expand the imagery download beyond the bounding box of your GeoJSON file. Defaults to 0 if not provided.
-* `PORT`: If running the Python scripts outside of Docker, you may choose to specify a different port for `tileserver-gl` to run on. Defaults to 8080 if not specified.
-
 ## Run
 
 ### Prerequisites

--- a/gccd_pkg/gccd/generate_tiles.py
+++ b/gccd_pkg/gccd/generate_tiles.py
@@ -63,6 +63,9 @@ def generate_raster_tiles(raster_imagery_url, raster_imagery_attribution, raster
             print(response.text)
 
     print("Downloading satellite imagery raster XYZ tiles...")
+    
+    # Much of the below code is adapted from Microsoft's Bing Maps Tile System documentation:
+    # https://learn.microsoft.com/en-us/bingmaps/articles/bing-maps-tile-system
     for zoom_level in range(1, int(raster_max_zoom) + 1):
         col_start, row_end = latlon_to_tilexy(bbox_top_left[1], bbox_top_left[0], zoom_level)
         col_end, row_start = latlon_to_tilexy(bbox_bottom_right[1], bbox_bottom_right[0], zoom_level)
@@ -113,7 +116,7 @@ def convert_xyz_to_mbtiles(output_directory, output_filename):
         os.remove(raster_mbtiles_output_path)
         print(f"Deleted existing MBTiles file: {raster_mbtiles_output_path}")
 
-    # Convert XYZ to MBtiles using mbutil
+    # Convert XYZ to MBtiles using mb-util
     command = f"mb-util --image_format=jpg --silent {xyz_output_dir} {raster_mbtiles_output_path}"
 
     print("Creating raster mbtiles...")

--- a/gccd_pkg/gccd/templates/overlay_map.html
+++ b/gccd_pkg/gccd/templates/overlay_map.html
@@ -19,7 +19,7 @@
 
     var map = new mapboxgl.Map({
       container: 'map',
-      style: 'mapbox://styles/mapbox/streets-v11',
+      style: 'mapbox://styles/mapbox/satellite-streets-v11',
       center: [0, 0],
       zoom: 1
     });

--- a/gccd_pkg/scripts/main.py
+++ b/gccd_pkg/scripts/main.py
@@ -11,7 +11,9 @@ from gccd.generate_tiles import generate_mbtiles_from_tileserver
 from gccd.serve_maps import serve_tileserver_gl
 
 
-port = os.getenv("PORT")
+port = os.getenv("PORT", 8080)
+raster_imagery_attribution = os.getenv("RASTER_IMAGERY_ATTRIBUTION", "")
+raster_max_zoom = os.getenv("RASTER_MBTILES_MAX_ZOOM", 14)
 
 
 def main():


### PR DESCRIPTION
A couple of small fixes:

* Most importantly, the (non-Dockerized) Python scripts were not running without a few missing env vars. I added these to `main.py` and set fallbacks.
* Using `satellite-streets-v11` in both HTML map templates.
* Added link for Bing maps documentation in a comment, in case we ever need to debug that code
* Moved the Configure section back to the root README.md (since it is needed for all execution methods), and clarified how to configure for each type of deployment. And added ALLOWED_API_KEY to the list.