### PR TITLE
Update property fields for alerts, and document API call for FastAPI

### DIFF
--- a/gccd_pkg/gccd/generate_style.py
+++ b/gccd_pkg/gccd/generate_style.py
@@ -78,7 +78,7 @@ def generate_style_with_mbtiles(raster_max_zoom, output_directory, output_filena
         "source-layer": output_filename,
         "filter": ["==", "$type", "Point"],
         "layout": {
-            'text-field': ['get', 'type_of_alert'],
+            'text-field': ['get', 'alert_type'],
             'text-font': ['Open Sans Regular'],
             'text-offset': [0, -0.5],
             'text-anchor': 'bottom',
@@ -99,7 +99,7 @@ def generate_style_with_mbtiles(raster_max_zoom, output_directory, output_filena
         "source-layer": output_filename,
         "filter": ['in', '$type', 'Polygon', 'LineString'],
         "layout": {
-            'text-field': ['get', 'type_of_alert'],
+            'text-field': ['get', 'alert_type'],
             'text-font': ['Open Sans Regular'],
             'text-offset': [0, 0.5],
             'text-anchor': 'top'

--- a/gccd_pkg/gccd/templates/map.html
+++ b/gccd_pkg/gccd/templates/map.html
@@ -108,7 +108,7 @@
 				source: 'geojson',
 				filter: ['in', '$type', 'Polygon', 'LineString'],
 				layout: {
-					'text-field': ['get', 'type_of_alert'],
+					'text-field': ['get', 'alert_type'],
 					'text-font': ['Noto Sans Medium'],
 					'text-offset': [0, -0.5],
 					'text-anchor': 'bottom',
@@ -128,7 +128,7 @@
 				source: 'geojson',
 				filter: ['==', '$type', 'Point'],
 				layout: {
-					'text-field': ['get', 'type_of_alert'],
+					'text-field': ['get', 'alert_type'],
 					'text-font': ['Noto Sans Medium'],
 					'text-offset': [0, -0.5],
 					'text-anchor': 'bottom',

--- a/gccd_pkg/gccd/templates/overlay_map.html
+++ b/gccd_pkg/gccd/templates/overlay_map.html
@@ -122,7 +122,7 @@
 				source: 'geojson',
 				filter: ['in', '$type', 'Polygon', 'LineString'],
 				layout: {
-					'text-field': ['get', 'type_of_alert'],
+					'text-field': ['get', 'alert_type'],
 					'text-font': ['Noto Sans Regular'],
 					'text-offset': [0, -0.5],
 					'text-anchor': 'bottom',
@@ -142,7 +142,7 @@
 				source: 'geojson',
 				filter: ['==', '$type', 'Point'],
 				layout: {
-					'text-field': ['get', 'type_of_alert'],
+					'text-field': ['get', 'alert_type'],
 					'text-font': ['Noto Sans Regular'],
 					'text-offset': [0, -0.5],
 					'text-anchor': 'bottom',

--- a/gccd_pkg/gccd/templates/swipe_map.html
+++ b/gccd_pkg/gccd/templates/swipe_map.html
@@ -103,7 +103,7 @@
             source: "geojson",
             filter: ["in", "$type", "Polygon", "LineString"],
             layout: {
-                "text-field": ["get", "type_of_alert"],
+                "text-field": ["get", "alert_type"],
                 "text-font": ["Noto Sans Regular"],
                 "text-offset": [0, -0.5],
                 "text-anchor": "bottom",
@@ -123,7 +123,7 @@
             source: "geojson",
             filter: ["==", "$type", "Point"],
             layout: {
-                "text-field": ["get", "type_of_alert"],
+                "text-field": ["get", "alert_type"],
                 "text-font": ["Noto Sans Medium"],
                 "text-offset": [0, -0.5],
                 "text-anchor": "bottom",

--- a/httpservice/README.md
+++ b/httpservice/README.md
@@ -35,3 +35,52 @@ In production:
 For local development with hot-reloading:
 
     docker run -it -v /home/cmi/dev/guardianconnector-change-detection/httpservice/app:/code/app -p 80:80 gccd uvicorn app.app:app --host 0.0.0.0 --port 80 --reload
+
+## Example API call
+
+``` sh
+curl -v -XPOST 'https://localhost:8080/changemaps/'  -H 'Content-Type: application/json' -d '{  "type": "FeatureCollection",
+  "name": "08142023-001",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "date_end_t0": "2023-09-30",
+        "date_end_t1": "2023-10-31",         
+        "alert_type": "gold mining",
+        "id": "2023101800161660100"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-54.117676498677, 3.312402112301291]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "date_end_t0": "2023-09-30",
+        "date_end_t1": "2023-10-31",        
+        "alert_type": "logging",
+        "id": "2023101800161660101"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-54.024968, 3.414382]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "date_end_t0": "2023-09-30",
+        "date_end_t1": "2023-10-31",
+        "alert_type": "land invasion",
+        "id": "2023101800161660102"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [-54.017286, 3.427148]
+      }
+    }
+  ]
+}' > changemap.tar
+```


### PR DESCRIPTION
This PR updates the different templates to use an `alert_type` instead of `type_of_alert` field for styling (per the actual schema of the alerts we are receiving), and adds a sample API call to the FastAPI server readme.