### PR TITLE
Expand FastAPI changemaps endpoint to receive input GeoTIFF binary in request payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /outputs/*
 !/outputs/.keep
+changemap.tar
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/httpservice/Dockerfile
+++ b/httpservice/Dockerfile
@@ -1,20 +1,21 @@
-FROM python:3.11-slim as tippecanoe-build-image
+FROM python:3.11-slim as map-utilities-build-image
 
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential libsqlite3-dev zlib1g-dev git
 RUN git clone https://github.com/felt/tippecanoe.git && cd tippecanoe && make -j && make install && cd .. && rm -r tippecanoe
 RUN apt-get install -y wget && \
-    wget https://github.com/protomaps/go-pmtiles/releases/download/v1.11.0/go-pmtiles_1.11.0_Linux_x86_64.tar.gz && \
-    tar -xzf go-pmtiles_1.11.0_Linux_x86_64.tar.gz && \
-    rm go-pmtiles_1.11.0_Linux_x86_64.tar.gz && \
+    wget https://github.com/protomaps/go-pmtiles/releases/download/v1.11.1/go-pmtiles_1.11.1_Linux_x86_64.tar.gz && \
+    tar -xzf go-pmtiles_1.11.1_Linux_x86_64.tar.gz && \
+    rm go-pmtiles_1.11.1_Linux_x86_64.tar.gz && \
     mv pmtiles /usr/local/bin
 
 #-#-#-#-#-#-#
 FROM python:3.11-slim
-COPY --from=tippecanoe-build-image /usr/local/bin/tile-join /usr/local/bin/tippecanoe* /usr/local/pmtiles /usr/local/bin/
+COPY --from=map-utilities-build-image /usr/local/bin/tile-join /usr/local/bin/tippecanoe* /usr/local/bin/pmtiles /usr/local/bin/
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
-RUN apt-get install -y binutils libproj-dev gdal-bin
+RUN apt-get update && \
+    apt-get install -y binutils libproj-dev gdal-bin
 
 # Take bleeding-edge auditor-core package (from tox build in build.sh).
 # We do not wait for a new auditor-core release (i.e. Git tag).

--- a/httpservice/Dockerfile
+++ b/httpservice/Dockerfile
@@ -3,9 +3,7 @@ FROM python:3.11-slim as map-utilities-build-image
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential libsqlite3-dev zlib1g-dev git
 RUN git clone https://github.com/felt/tippecanoe.git && cd tippecanoe && make -j && make install && cd .. && rm -r tippecanoe
 RUN apt-get install -y wget && \
-    wget https://github.com/protomaps/go-pmtiles/releases/download/v1.11.1/go-pmtiles_1.11.1_Linux_x86_64.tar.gz && \
-    tar -xzf go-pmtiles_1.11.1_Linux_x86_64.tar.gz && \
-    rm go-pmtiles_1.11.1_Linux_x86_64.tar.gz && \
+    wget -qO- https://github.com/protomaps/go-pmtiles/releases/download/v1.11.1/go-pmtiles_1.11.1_Linux_x86_64.tar.gz | tar -xz && \
     mv pmtiles /usr/local/bin
 
 #-#-#-#-#-#-#

--- a/httpservice/README.md
+++ b/httpservice/README.md
@@ -34,12 +34,12 @@ In production:
 
 For local development with hot-reloading:
 
-    docker run -it -v /home/cmi/dev/guardianconnector-change-detection/httpservice/app:/code/app -p 80:80 gccd uvicorn app.app:app --host 0.0.0.0 --port 80 --reload
+    docker run -it -v /home/cmi/dev/guardianconnector-change-detection/httpservice/app:/code/app -p 80:80 --env-file .env gccd uvicorn app.app:app --host 0.0.0.0 --port 80 --reload
 
 ## Example API call
 
 ``` sh
-curl -v -XPOST 'https://localhost:8080/changemaps/'  -H 'Content-Type: application/json' -d '{  "type": "FeatureCollection",
+curl -v -XPOST 'http://localhost:80/changemaps/' -H 'Content-Type: application/json' -H 'X-API-KEY: "your-api-key"' -d '{  "type": "FeatureCollection",
   "name": "08142023-001",
   "features": [
     {

--- a/httpservice/README.md
+++ b/httpservice/README.md
@@ -39,7 +39,7 @@ For local development with hot-reloading:
 ## Example API call
 
 ``` sh
-curl -v -XPOST 'http://localhost:80/changemaps/' -H 'Content-Type: application/json' -H 'X-API-KEY: "your-api-key"' -d '{  "type": "FeatureCollection",
+curl -v -XPOST 'http://localhost:80/changemaps/' -H 'Content-Type: application/json' -H 'X-API-KEY: your-api-key' -d '{  "type": "FeatureCollection",
   "name": "08142023-001",
   "features": [
     {

--- a/httpservice/README.md
+++ b/httpservice/README.md
@@ -36,51 +36,63 @@ For local development with hot-reloading:
 
     docker run -it -v /home/cmi/dev/guardianconnector-change-detection/httpservice/app:/code/app -p 80:80 --env-file .env gccd uvicorn app.app:app --host 0.0.0.0 --port 80 --reload
 
-## Example API call
+## Payload structure
+
+The `changemaps` endpoint expects a JSON payload consisting of three values, one required and two optional:
+
+* `input_geojson` (array, required): this is a GeoJSON feature collection which will be saved as a temp file and used for the `input_geojson_path` by the GCCD flow.
+* `input_t0` and `input_t1` (string, optional): base64-encoded data strings for the t0 and t1 GeoTIFFs, if provided. 
+
+### Example API call
+
+This is providing just `input_geojson`.
 
 ``` sh
-curl -v -XPOST 'http://localhost:80/changemaps/' -H 'Content-Type: application/json' -H 'X-API-KEY: your-api-key' -d '{  "type": "FeatureCollection",
-  "name": "08142023-001",
-  "features": [
-    {
-      "type": "Feature",
-      "properties": {
-        "date_end_t0": "2023-09-30",
-        "date_end_t1": "2023-10-31",         
-        "alert_type": "gold mining",
-        "id": "2023101800161660100"
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-54.117676498677, 3.312402112301291]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "date_end_t0": "2023-09-30",
-        "date_end_t1": "2023-10-31",        
-        "alert_type": "logging",
-        "id": "2023101800161660101"
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-54.024968, 3.414382]
-      }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "date_end_t0": "2023-09-30",
-        "date_end_t1": "2023-10-31",
-        "alert_type": "land invasion",
-        "id": "2023101800161660102"
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [-54.017286, 3.427148]
-      }
-    }
-  ]
+curl -v -XPOST 'http://localhost:80/changemaps/' -H 'Content-Type: application/json' -H 'X-API-KEY: your-api-key' -d '{  
+  "input_geojson": {
+    "type": "FeatureCollection",
+    "name": "08142023-001",
+    "features": [
+        {
+        "type": "Feature",
+            "properties": {
+                "date_end_t0": "2023-09-30",
+                "date_end_t1": "2023-10-31",         
+                "alert_type": "gold mining",
+                "id": "2023101800161660100"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [-54.117676498677, 3.312402112301291]
+            }
+        },
+        {
+        "type": "Feature",
+            "properties": {
+                "date_end_t0": "2023-09-30",
+                "date_end_t1": "2023-10-31",        
+                "alert_type": "logging",
+                "id": "2023101800161660101"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [-54.024968, 3.414382]
+            }
+        },
+            {
+            "type": "Feature",
+            "properties": {
+                "date_end_t0": "2023-09-30",
+                "date_end_t1": "2023-10-31",
+                "alert_type": "land invasion",
+                "id": "2023101800161660102"
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [-54.017286, 3.427148]
+            }
+        }
+    ]
+  }
 }' > changemap.tar
 ```

--- a/httpservice/app/app.py
+++ b/httpservice/app/app.py
@@ -4,7 +4,7 @@ import tarfile
 import tempfile
 import base64
 from typing import Any, Optional
-
+from pydantic import BaseModel, Field
 
 import fastapi
 import gccd
@@ -41,14 +41,17 @@ def create_tarfile(directory, tar_filename):
                 relative_path = os.path.relpath(full_path, directory)
                 tar.add(full_path, arcname=relative_path)
 
+class ChangemapRequestData(BaseModel):
+    input_geojson: dict
+    images: dict = Field(default_factory=dict)
 
 @app.post("/changemaps/", dependencies=[fastapi.Security(check_apikey_header)])
 async def make_changemaps(
-    data: dict = fastapi.Body(...),
+    data: ChangemapRequestData,
     output_tar=fastapi.Depends(sendable_tempfile)
 ):
-    input_geojson = data.get("input_geojson")
-    images = data.get("images", {})
+    input_geojson = data.input_geojson
+    images = data.images
 
     with tempfile.NamedTemporaryFile(
         "w+", prefix="input-", suffix=".json"

--- a/httpservice/app/app.py
+++ b/httpservice/app/app.py
@@ -51,7 +51,7 @@ async def make_changemaps(
         input_fp.flush()
         input_fp.seek(0)
 
-        gccd.flow(input_fp.name, outdir, "output")
+        gccd.flow(input_fp.name, None, None, outdir, "output")
 
         create_tarfile(outdir, output_tar)
 

--- a/httpservice/app/app.py
+++ b/httpservice/app/app.py
@@ -48,27 +48,29 @@ async def make_changemaps(
     output_tar=fastapi.Depends(sendable_tempfile)
 ):
     input_geojson = data.get("input_geojson")
-    input_t0 = data.get("input_t0")
-    input_t1 = data.get("input_t1")
+    images = data.get("images", {})
 
     with tempfile.NamedTemporaryFile(
         "w+", prefix="input-", suffix=".json"
     ) as input_fp, tempfile.TemporaryDirectory() as outdir:
 
-        # Dump feacoll to temp file
+        # Dump input geojson to temp file
         json.dump(input_geojson, input_fp)
         input_fp.flush()
         input_fp.seek(0)
 
-        # Decode and save input_t0 and input_t1 (if provided)
-        if input_t0:
-            input_t0 = save_base64_to_tempfile(input_t0_base64, suffix=".tiff")
+        t0 = images.get("t0")
+        t1 = images.get("t1")
 
-        if input_t1:
-            input_t1 = save_base64_to_tempfile(input_t1_base64, suffix=".tiff")
-
-        # Run the GCCD flow()
-        gccd.flow(input_fp.name, input_t0, input_t1, outdir, "output")
+        # Run GCCD.flow()
+        # With GeoTIFF inputs:
+        if t0 and t1:
+            with WriteToTempFile(images["t0"], suffix=".tif") as t0_fp, \
+            WriteToTempFile(images["t1"], suffix=".tif") as t1_fp: \
+            gccd.flow(input_fp.name, t0_fp, t1_fp, outdir, "output")
+        # Without GeoTIFF inputs:
+        else:
+            gccd.flow(input_fp.name, None, None, outdir, "output")
 
         create_tarfile(outdir, output_tar)
 
@@ -77,13 +79,23 @@ async def make_changemaps(
         headers={"Content-Disposition": "attachment; filename=changemap.tar"},
     )
 
-def save_base64_to_tempfile(base64_str, suffix=""):
-    """
-    Decode base64 string and write to a temporary file.
-    Return the path of the temporary file.
-    """
-    binary_data = base64.b64decode(base64_str)
-    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
-    with open(temp_file.name, 'wb') as file:
-        file.write(binary_data)
-    return temp_file.name
+class WriteToTempFile:
+    def __init__(self, base64_str, suffix=""):
+        self.base64_str = base64_str
+        self.suffix = suffix
+
+    def __enter__(self):
+        # Create a temporary file with the specified suffix
+        self.temp_file = tempfile.NamedTemporaryFile(suffix=self.suffix, delete=False)
+
+        # Decode the base64 string and write to the temporary file
+        decoded_data = base64.b64decode(self.base64_str)
+        self.temp_file.write(decoded_data)
+        self.temp_file.close()
+
+        # Return the temporary file name
+        return self.temp_file.name
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # Delete the temporary file when the context exits
+        os.remove(self.temp_file.name)


### PR DESCRIPTION
Just sharing where I've gotten today. This branch is expanding the FastAPI `changemaps` endpoint to receive input GeoTIFF binary content in the request payload in addition to a change detection alert GeoJSON feature collection.

* The `changemaps` endpoint is now expecting key/value pairs in the JSON payload. `input_geojson` (formerly `feacoll`) works the same as before - it is expected to be a feature collection array, to be saved as a tempfile and passed to the GCCD flow.
* You can provide `input_t1` and `input_t2` in the request body - these are optional base64 strings, also to be saved as tempfiles and used as the geotiff inputs for the GCCD flow. I haven't actually tried this out yet, but I figure this is a good way for frizzle `terras` component to pass the GeoTIFF binary data to GCCD once received.
* To get GCCD FastAPI working again, I had to fix a few things in the Dockerfile - I fixed an incorrect path which I missed in my last pmtiles refactor, updated the `go-pmtiles` library to the latest version, and am updating apt-get repositories since the image was failing to build one or more of the packages without doing so.