### PR TITLE
Add a step to create JPG images from GeoTIFFs using gdal_translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can execute this script in one of three ways:
 
 The script follows these steps:
 
-1. Copy GeoJSON file to outputs directory
+1. Copy GeoJSON file to outputs directory, and generate a JPG version of the GeoTIFFs (if provided)
 2. Get bounding box for GeoJSON (all features)
 3. Generate PMTiles from GeoTIFFS (if provided)
 4. Generate HTML map for previewing change detection alert (a swipe map if GeoTIFFs are provided)
@@ -93,10 +93,13 @@ example/
 │       └── example-vector.mbtiles
 └─ resources
     ├── example.geojson
+    ├── example_t0.jpg
+    ├── example_t1.jpg
     ├── example_t0.pmtiles
     ├── example_t1.pmtiles
     ├── example_t0.tif
     └── example_t1.tif
+
 ```
 
 ## How to use the outputs

--- a/docker-generate.py
+++ b/docker-generate.py
@@ -2,7 +2,7 @@ import os
 import sys
 import argparse
 import traceback
-from gccd.utils import copy_input_files
+from gccd.utils import copy_input_files, generate_jpgs_from_geotiffs
 from gccd.calculate_bbox import get_bounding_box
 from gccd.generate_maps import generate_html_map, generate_overlay_map
 from gccd.generate_tiles import (
@@ -65,8 +65,10 @@ def main():
         if os.path.exists(f"{output_directory}\mapgl-map\config.json"):
             os.remove(f"{output_directory}\config.json")    
 
-        # STEP 1: Copy input files to resources
+        # STEP 1: Copy input files to resources, and generate a JPG version of the GeoTIFFs (if provided)
         copy_input_files(input_geojson_path, input_t0_path, input_t1_path, output_directory, output_filename)
+        if input_t0_path is not None and input_t1_path is not None:
+            generate_jpgs_from_geotiffs(input_t0_path, input_t1_path, output_directory, output_filename)
 
         # STEP 2: Get bounding box for GeoJSON
         bounding_box = get_bounding_box(input_geojson_path, raster_buffer_size)

--- a/gccd_pkg/gccd/__init__.py
+++ b/gccd_pkg/gccd/__init__.py
@@ -10,7 +10,7 @@ from gccd.generate_tiles import (
 )
 from gccd.generate_style import generate_style_with_mbtiles
 from gccd.generate_fonts_sprites import copy_fonts_and_sprites
-from gccd.utils import copy_input_files
+from gccd.utils import copy_input_files, generate_jpgs_from_geotiffs
 
 
 # Get environment variables
@@ -25,8 +25,10 @@ raster_buffer_size = os.getenv("RASTER_BUFFER_SIZE")
 
 def flow(input_geojson_path, input_t0_path, input_t1_path, output_directory, output_filename):
 
-    # STEP 1: Copy input files to resources/
+    # STEP 1: Copy input files to resources, and generate a JPG version of the GeoTIFFs (if provided)
     copy_input_files(input_geojson_path, input_t0_path, input_t1_path, output_directory, output_filename)
+    if input_t0_path is not None and input_t1_path is not None:
+        generate_jpgs_from_geotiffs(input_t0_path, input_t1_path, output_directory, output_filename)
 
     # STEP 2: Get bounding box for GeoJSON
     bounding_box = get_bounding_box(input_geojson_path, raster_buffer_size)

--- a/gccd_pkg/gccd/utils.py
+++ b/gccd_pkg/gccd/utils.py
@@ -45,6 +45,29 @@ def copy_input_files(input_geojson_path, input_t0_path, input_t1_path, output_di
             print(f"\033[1m\033[31mError copying GeoTIFF files:\033[0m {e}")
             sys.exit(1)
 
+def generate_jpgs_from_geotiffs(input_t0_path, input_t1_path, output_directory, output_filename):
+    resources_dir = os.path.join(output_directory, "resources")
+    os.makedirs(resources_dir, exist_ok=True)
+
+    # Generate JPGs from GeoTIFFs
+    try:
+        # Determine the JPG output filenames
+        t0_output_filename = os.path.basename(f'{output_filename}_t0.jpg')
+        t1_output_filename = os.path.basename(f'{output_filename}_t1.jpg')
+        # Determine the full path to the JPG output files
+        t0_output_path = os.path.join(resources_dir, t0_output_filename)
+        t1_output_path = os.path.join(resources_dir, t1_output_filename)
+        # Generate the JPG files
+        subprocess.check_output(['gdal_translate', '-of', 'JPEG', input_t0_path, t0_output_path])
+        subprocess.check_output(['gdal_translate', '-of', 'JPEG', input_t1_path, t1_output_path])
+        # Delete the xml artifacts that gdal_translate generates
+        os.remove(f'{t0_output_path}.aux.xml')
+        os.remove(f'{t1_output_path}.aux.xml')
+        print(f"\033[1m\033[32mT0 and T1 JPG files generated and saved to:\033[0m {resources_dir}")
+    except subprocess.CalledProcessError as e:
+        print(f"\033[1m\033[31mAn error occurred trying to generate JPG files:\033[0m {e}")
+        sys.exit(1)
+
 def read_geojson_file(input_path):
     try:
         with open(input_path, 'r') as geojson_file:

--- a/httpservice/app/app.py
+++ b/httpservice/app/app.py
@@ -4,7 +4,11 @@ import tarfile
 import tempfile
 import base64
 from typing import Any, Optional
+<<<<<<< HEAD
 from pydantic import BaseModel, Field
+=======
+
+>>>>>>> 6455d80 (Receive base64 t0 and t1 inputs in JSON payload)
 
 import fastapi
 import gccd
@@ -47,21 +51,35 @@ class ChangemapRequestData(BaseModel):
 
 @app.post("/changemaps/", dependencies=[fastapi.Security(check_apikey_header)])
 async def make_changemaps(
+<<<<<<< HEAD
     data: ChangemapRequestData,
     output_tar=fastapi.Depends(sendable_tempfile)
 ):
     input_geojson = data.input_geojson
     images = data.images
+=======
+    data: dict = fastapi.Body(...),
+    output_tar=fastapi.Depends(sendable_tempfile)
+):
+    input_geojson = data.get("input_geojson")
+    input_t0 = data.get("input_t0")
+    input_t1 = data.get("input_t1")
+>>>>>>> 6455d80 (Receive base64 t0 and t1 inputs in JSON payload)
 
     with tempfile.NamedTemporaryFile(
         "w+", prefix="input-", suffix=".json"
     ) as input_fp, tempfile.TemporaryDirectory() as outdir:
 
+<<<<<<< HEAD
         # Dump input geojson to temp file
+=======
+        # Dump feacoll to temp file
+>>>>>>> 6455d80 (Receive base64 t0 and t1 inputs in JSON payload)
         json.dump(input_geojson, input_fp)
         input_fp.flush()
         input_fp.seek(0)
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         t0 = images.get("t0")
         t1 = images.get("t1")
@@ -78,6 +96,17 @@ async def make_changemaps(
 =======
         gccd.flow(input_fp.name, None, None, outdir, "output")
 >>>>>>> 029aefc (Get FastAPI minimally working again)
+=======
+        # Decode and save input_t0 and input_t1 (if provided)
+        if input_t0:
+            input_t0 = save_base64_to_tempfile(input_t0_base64, suffix=".tiff")
+
+        if input_t1:
+            input_t1 = save_base64_to_tempfile(input_t1_base64, suffix=".tiff")
+
+        # Run the GCCD flow()
+        gccd.flow(input_fp.name, input_t0, input_t1, outdir, "output")
+>>>>>>> 6455d80 (Receive base64 t0 and t1 inputs in JSON payload)
 
         create_tarfile(outdir, output_tar)
 
@@ -86,6 +115,7 @@ async def make_changemaps(
         headers={"Content-Disposition": "attachment; filename=changemap.tar"},
     )
 
+<<<<<<< HEAD
 class WriteToTempFile:
     def __init__(self, base64_str, suffix=""):
         self.base64_str = base64_str
@@ -106,3 +136,15 @@ class WriteToTempFile:
     def __exit__(self, exc_type, exc_value, traceback):
         # Delete the temporary file when the context exits
         os.remove(self.temp_file.name)
+=======
+def save_base64_to_tempfile(base64_str, suffix=""):
+    """
+    Decode base64 string and write to a temporary file.
+    Return the path of the temporary file.
+    """
+    binary_data = base64.b64decode(base64_str)
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+    with open(temp_file.name, 'wb') as file:
+        file.write(binary_data)
+    return temp_file.name
+>>>>>>> 6455d80 (Receive base64 t0 and t1 inputs in JSON payload)

--- a/httpservice/app/app.py
+++ b/httpservice/app/app.py
@@ -4,11 +4,7 @@ import tarfile
 import tempfile
 import base64
 from typing import Any, Optional
-<<<<<<< HEAD
 from pydantic import BaseModel, Field
-=======
-
->>>>>>> 6455d80 (Receive base64 t0 and t1 inputs in JSON payload)
 
 import fastapi
 import gccd
@@ -51,43 +47,33 @@ class ChangemapRequestData(BaseModel):
 
 @app.post("/changemaps/", dependencies=[fastapi.Security(check_apikey_header)])
 async def make_changemaps(
-<<<<<<< HEAD
     data: ChangemapRequestData,
     output_tar=fastapi.Depends(sendable_tempfile)
 ):
     input_geojson = data.input_geojson
     images = data.images
-=======
-    data: dict = fastapi.Body(...),
-    output_tar=fastapi.Depends(sendable_tempfile)
-):
-    input_geojson = data.get("input_geojson")
-    input_t0 = data.get("input_t0")
-    input_t1 = data.get("input_t1")
->>>>>>> 6455d80 (Receive base64 t0 and t1 inputs in JSON payload)
 
     with tempfile.NamedTemporaryFile(
         "w+", prefix="input-", suffix=".json"
     ) as input_fp, tempfile.TemporaryDirectory() as outdir:
 
-<<<<<<< HEAD
         # Dump input geojson to temp file
-=======
-        # Dump feacoll to temp file
->>>>>>> 6455d80 (Receive base64 t0 and t1 inputs in JSON payload)
         json.dump(input_geojson, input_fp)
         input_fp.flush()
         input_fp.seek(0)
 
-        # Decode and save input_t0 and input_t1 (if provided)
-        if input_t0:
-            input_t0 = save_base64_to_tempfile(input_t0_base64, suffix=".tiff")
+        t0 = images.get("t0")
+        t1 = images.get("t1")
 
-        if input_t1:
-            input_t1 = save_base64_to_tempfile(input_t1_base64, suffix=".tiff")
-
-        # Run the GCCD flow()
-        gccd.flow(input_fp.name, input_t0, input_t1, outdir, "output")
+        # Run GCCD.flow()
+        # With GeoTIFF inputs:
+        if t0 and t1:
+            with WriteToTempFile(images["t0"], suffix=".tif") as t0_fp, \
+            WriteToTempFile(images["t1"], suffix=".tif") as t1_fp: \
+            gccd.flow(input_fp.name, t0_fp, t1_fp, outdir, "output")
+        # Without GeoTIFF inputs:
+        else:
+            gccd.flow(input_fp.name, None, None, outdir, "output")
 
         create_tarfile(outdir, output_tar)
 
@@ -96,13 +82,23 @@ async def make_changemaps(
         headers={"Content-Disposition": "attachment; filename=changemap.tar"},
     )
 
-def save_base64_to_tempfile(base64_str, suffix=""):
-    """
-    Decode base64 string and write to a temporary file.
-    Return the path of the temporary file.
-    """
-    binary_data = base64.b64decode(base64_str)
-    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
-    with open(temp_file.name, 'wb') as file:
-        file.write(binary_data)
-    return temp_file.name
+class WriteToTempFile:
+    def __init__(self, base64_str, suffix=""):
+        self.base64_str = base64_str
+        self.suffix = suffix
+
+    def __enter__(self):
+        # Create a temporary file with the specified suffix
+        self.temp_file = tempfile.NamedTemporaryFile(suffix=self.suffix, delete=False)
+
+        # Decode the base64 string and write to the temporary file
+        decoded_data = base64.b64decode(self.base64_str)
+        self.temp_file.write(decoded_data)
+        self.temp_file.close()
+
+        # Return the temporary file name
+        return self.temp_file.name
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # Delete the temporary file when the context exits
+        os.remove(self.temp_file.name)

--- a/httpservice/app/app.py
+++ b/httpservice/app/app.py
@@ -79,24 +79,6 @@ async def make_changemaps(
         input_fp.flush()
         input_fp.seek(0)
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        t0 = images.get("t0")
-        t1 = images.get("t1")
-
-        # Run GCCD.flow()
-        # With GeoTIFF inputs:
-        if t0 and t1:
-            with WriteToTempFile(images["t0"], suffix=".tif") as t0_fp, \
-            WriteToTempFile(images["t1"], suffix=".tif") as t1_fp: \
-            gccd.flow(input_fp.name, t0_fp, t1_fp, outdir, "output")
-        # Without GeoTIFF inputs:
-        else:
-            gccd.flow(input_fp.name, None, None, outdir, "output")
-=======
-        gccd.flow(input_fp.name, None, None, outdir, "output")
->>>>>>> 029aefc (Get FastAPI minimally working again)
-=======
         # Decode and save input_t0 and input_t1 (if provided)
         if input_t0:
             input_t0 = save_base64_to_tempfile(input_t0_base64, suffix=".tiff")
@@ -106,7 +88,6 @@ async def make_changemaps(
 
         # Run the GCCD flow()
         gccd.flow(input_fp.name, input_t0, input_t1, outdir, "output")
->>>>>>> 6455d80 (Receive base64 t0 and t1 inputs in JSON payload)
 
         create_tarfile(outdir, output_tar)
 
@@ -115,28 +96,6 @@ async def make_changemaps(
         headers={"Content-Disposition": "attachment; filename=changemap.tar"},
     )
 
-<<<<<<< HEAD
-class WriteToTempFile:
-    def __init__(self, base64_str, suffix=""):
-        self.base64_str = base64_str
-        self.suffix = suffix
-
-    def __enter__(self):
-        # Create a temporary file with the specified suffix
-        self.temp_file = tempfile.NamedTemporaryFile(suffix=self.suffix, delete=False)
-
-        # Decode the base64 string and write to the temporary file
-        decoded_data = base64.b64decode(self.base64_str)
-        self.temp_file.write(decoded_data)
-        self.temp_file.close()
-
-        # Return the temporary file name
-        return self.temp_file.name
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        # Delete the temporary file when the context exits
-        os.remove(self.temp_file.name)
-=======
 def save_base64_to_tempfile(base64_str, suffix=""):
     """
     Decode base64 string and write to a temporary file.
@@ -147,4 +106,3 @@ def save_base64_to_tempfile(base64_str, suffix=""):
     with open(temp_file.name, 'wb') as file:
         file.write(binary_data)
     return temp_file.name
->>>>>>> 6455d80 (Receive base64 t0 and t1 inputs in JSON payload)

--- a/httpservice/app/app.py
+++ b/httpservice/app/app.py
@@ -62,6 +62,7 @@ async def make_changemaps(
         input_fp.flush()
         input_fp.seek(0)
 
+<<<<<<< HEAD
         t0 = images.get("t0")
         t1 = images.get("t1")
 
@@ -74,6 +75,9 @@ async def make_changemaps(
         # Without GeoTIFF inputs:
         else:
             gccd.flow(input_fp.name, None, None, outdir, "output")
+=======
+        gccd.flow(input_fp.name, None, None, outdir, "output")
+>>>>>>> 029aefc (Get FastAPI minimally working again)
 
         create_tarfile(outdir, output_tar)
 


### PR DESCRIPTION
Closes #18.

This PR adds a step to generate JPG images from the input GeoTIFFs (if provided) to the `resources/` directory. These images can be used for rendering the before/after imagery in a browser, among other things.

(Sloppy commit history because I branched off a merged branch, and forgot to fetch latest `main`; but will squash & merge)